### PR TITLE
Update arduocam.rst to clarify replacement cameras

### DIFF
--- a/docs/source/pages/arducam.rst
+++ b/docs/source/pages/arducam.rst
@@ -39,7 +39,7 @@ Some of these have **M12 mount**, so you can use a variety of **different lenses
 - and `others <https://www.arducam.com/product-category/lenses/m12-lens-arducam/>`__
 
 Replacement stereo cameras for OAK-D-PCBA
-************************************
+*****************************************
 
 The cameras below are compatible with the OAK-D-PCBA.  Due to the use of adhesives to affix the cameras in the assembled OAK-D, it is difficult to replace them.  Attempting to remove the cameras can cause damage to both the cameras and the pcb.
 

--- a/docs/source/pages/arducam.rst
+++ b/docs/source/pages/arducam.rst
@@ -42,7 +42,8 @@ Replacement stereo cameras for OAK-D-PCBA
 *****************************************
 
 The cameras below are compatible with the OAK-D-PCBA.  Due to the use of adhesives to affix the cameras in the assembled OAK-D, it is difficult to replace them.  Attempting to remove the cameras can cause damage to both the cameras and the pcb.
-
+The best and easiest way to remove the old Compact Camera Modules from the PCBA is to apply a small amount of IPA around the CCM to soften the permanent glue. 
+After that a scalpel or any other similar tool should be used slicing the camera off of the PCB (cutting the glue in between the CCM and PCB). 
 - Compact Camera Module (CCM) Fish-Eye OV9282 (for better SLAM) `here <https://www.arducam.com/product/arducam-1mp-ov9282-fisheye-mono-global-shutter-drop-in-replacement-for-depthai-oak-dnoir/>`__
 - Mechanical, Optical, and Electrical equivalent OV9282 module with visible and IR capability `here <https://www.arducam.com/product/arducam-1mp-ov9282-ccm-drop-in-replacement-for-oak-d/>`__
 - Global-Shutter Color Camera (OV9782) with same intrinsics as OV9282 grayscale `here <https://www.arducam.com/product/arducam-1mp-ov9782-color-global-shutter-drop-in-replacement-for-depthai-oak-dnoir-b0352/>`__

--- a/docs/source/pages/arducam.rst
+++ b/docs/source/pages/arducam.rst
@@ -38,8 +38,10 @@ Some of these have **M12 mount**, so you can use a variety of **different lenses
 - `M2506ZH04 (HFoV: 33°C) <https://www.arducam.com/product/M2506ZH04/>`__,
 - and `others <https://www.arducam.com/product-category/lenses/m12-lens-arducam/>`__
 
-Replacement stereo cameras for OAK-D
+Replacement stereo cameras for OAK-D-PCBA
 ************************************
+
+The cameras below are compatible with the OAK-D-PCBA.  Due to the use of adhesives to affix the cameras in the assembled OAK-D, it is difficult to replace them.  Attempting to remove the cameras can cause damage to both the cameras and the pcb.
 
 - Compact Camera Module (CCM) Fish-Eye OV9282 (for better SLAM) `here <https://www.arducam.com/product/arducam-1mp-ov9282-fisheye-mono-global-shutter-drop-in-replacement-for-depthai-oak-dnoir/>`__
 - Mechanical, Optical, and Electrical equivalent OV9282 module with visible and IR capability `here <https://www.arducam.com/product/arducam-1mp-ov9282-ccm-drop-in-replacement-for-oak-d/>`__

--- a/docs/source/pages/arducam.rst
+++ b/docs/source/pages/arducam.rst
@@ -41,9 +41,10 @@ Some of these have **M12 mount**, so you can use a variety of **different lenses
 Replacement stereo cameras for OAK-D-PCBA
 *****************************************
 
-The cameras below are compatible with the OAK-D-PCBA.  Due to the use of adhesives to affix the cameras in the assembled OAK-D, it is difficult to replace them.  Attempting to remove the cameras can cause damage to both the cameras and the pcb.
-The best and easiest way to remove the old Compact Camera Modules from the PCBA is to apply a small amount of IPA around the CCM to soften the permanent glue. 
-After that a scalpel or any other similar tool should be used slicing the camera off of the PCB (cutting the glue in between the CCM and PCB). 
+The cameras below are compatible with the OAK-D-PCBA.  Due to the use of adhesives to affix the cameras in the assembled OAK-D, it is difficult to replace them.  Attempting to remove the cameras can cause damage to both the cameras and the PCB.
+
+The best and easiest way to remove the old Compact Camera Modules (CCM) from the PCBA is to apply a small amount of IPA around the CCM to soften the permanent glue. After that, a scalpel or any other similar tool should be used slicing the camera off of the PCB, by cutting the glue in between the CCM and PCB. 
+
 - Compact Camera Module (CCM) Fish-Eye OV9282 (for better SLAM) `here <https://www.arducam.com/product/arducam-1mp-ov9282-fisheye-mono-global-shutter-drop-in-replacement-for-depthai-oak-dnoir/>`__
 - Mechanical, Optical, and Electrical equivalent OV9282 module with visible and IR capability `here <https://www.arducam.com/product/arducam-1mp-ov9282-ccm-drop-in-replacement-for-oak-d/>`__
 - Global-Shutter Color Camera (OV9782) with same intrinsics as OV9282 grayscale `here <https://www.arducam.com/product/arducam-1mp-ov9782-color-global-shutter-drop-in-replacement-for-depthai-oak-dnoir-b0352/>`__

--- a/docs/source/pages/arducam.rst
+++ b/docs/source/pages/arducam.rst
@@ -43,7 +43,7 @@ Replacement stereo cameras for OAK-D-PCBA
 
 The cameras below are compatible with the OAK-D-PCBA.  Due to the use of adhesives to affix the cameras in the assembled OAK-D, it is difficult to replace them.  Attempting to remove the cameras can cause damage to both the cameras and the PCB.
 
-The best and easiest way to remove the old Compact Camera Modules (CCM) from the PCBA is to apply a small amount of IPA around the CCM to soften the permanent glue. After that, a scalpel or any other similar tool should be used slicing the camera off of the PCB, by cutting the glue in between the CCM and PCB. 
+The best and easiest way to remove the old Compact Camera Modules (CCM) from the PCBA is to apply a small amount of acetone or IPA (isopropyl alcohol) around the CCM to soften the permanent glue. After that, a scalpel or any other similar tool should be used slicing the camera off of the PCB, by cutting the glue in between the CCM and PCB. 
 
 - Compact Camera Module (CCM) Fish-Eye OV9282 (for better SLAM) `here <https://www.arducam.com/product/arducam-1mp-ov9282-fisheye-mono-global-shutter-drop-in-replacement-for-depthai-oak-dnoir/>`__
 - Mechanical, Optical, and Electrical equivalent OV9282 module with visible and IR capability `here <https://www.arducam.com/product/arducam-1mp-ov9282-ccm-drop-in-replacement-for-oak-d/>`__


### PR DESCRIPTION
The current language is a bit confusing to me and I thought these would work in an OAK-D.  Though they may actually work, doing so requires using a solvent to remove the glue the affixes the cameras, which may cause damage to the board (depending upon how talented a repair person you are).