### PR TITLE
OAK SoM Max, supplemental feature info

### DIFF
--- a/docs/source/pages/DM3399.rst
+++ b/docs/source/pages/DM3399.rst
@@ -42,6 +42,10 @@ Key features
 * 2 x 2-lane and 1x 4-lane MIPI TX lines
 * USB 3.1 Gen 2
 * Design files produced with Altium Designer 20
+* Voltage levels: All I2C busses are 1.8V
+* Pull-up resistors: 2.2k pull-up resistors located on SoM
+* Min/max data rates: Keembay supports the following, all on I2C busses: 1) Standard Mode (100kHz), 2) Fast Mode (400kHz), 3) Fast Mode Plus (1MHz), and 4) High Speed Mode (3.4MHz)
+* I2C0 bus devices: RTC circuit (address 0xD2) and EEPROM (address 0x50)
 
 Files
 *****


### PR DESCRIPTION
Questions from customer + answers from Nejc:

1. What are the voltage levels?  All I2C busses are 1.8V Level
2. Are pull-up resistors on the carrier or on the module? Correct we have 2.2k pull-up resistors on the SOM
3. What is the maximum/minimum data rate? The Keembay supports the standard (100kHz), Fast mode (400Khz), Fast mode plus (1MHz) and High speed mode (3.4MHz) on all I2C busses 
4. Are there extra devices on the module we need to be aware of to avoid I2C device conflict? The following devices occupy I2C0 bus:
RTC circuit (address 0xD2) 
EEPROM (address 0x50)