### PR TITLE
Updated max FPS at 720p and 800p for OV9x82 sensors

### DIFF
--- a/docs/source/pages/OAK-D-SR-POE.rst
+++ b/docs/source/pages/OAK-D-SR-POE.rst
@@ -56,7 +56,7 @@ Camera module specifications
      - FF: 20cm - ∞
      - 20cm - 5m
    * - Max Framerate
-     - 60 FPS (800P)
+     - 120 FPS (800P)
      - 30 FPS (VGA)
    * - Pixel size
      - 3µm x 3µm

--- a/docs/source/pages/OAK-D-SR.rst
+++ b/docs/source/pages/OAK-D-SR.rst
@@ -44,7 +44,7 @@ Camera module specifications
    * - Focus
      - FF: 20cm - ∞
    * - Max Framerate
-     - 60 FPS (800P)
+     - 120 FPS (800P)
    * - F-number
      - 2.0 ±5%
    * - Lens size

--- a/docs/source/pages/articles/sensors/ov9282.rst
+++ b/docs/source/pages/articles/sensors/ov9282.rst
@@ -17,11 +17,11 @@ Supported resolutions
      - MIPI lanes
    * - THE_800_P
      - 1280x800
-     - 60 FPS
+     - 120 FPS
      - 2
    * - THE_720_P
      - 1280x720
-     - 60 FPS
+     - 120 FPS
      - 2
    * - THE_400_P
      - 640x400

--- a/docs/source/pages/articles/sensors/ov9782.rst
+++ b/docs/source/pages/articles/sensors/ov9782.rst
@@ -17,11 +17,11 @@ Supported resolutions
      - MIPI lanes
    * - THE_800_P
      - 1280x800
-     - 60 FPS
+     - 120 FPS
      - 2
    * - THE_720_P
      - 1280x720
-     - 60 FPS
+     - 120 FPS
      - 2
    * - THE_400_P
      - 640x400

--- a/docs/source/pages/includes/ov9782_ov9282_w.rst
+++ b/docs/source/pages/includes/ov9782_ov9282_w.rst
@@ -24,7 +24,7 @@ Camera module specifications
      - FF: 18cm - ∞
    * - Max Framerate
      - 120 FPS (800P)
-     - 120 FPS (400P)
+     - 120 FPS (800P)
    * - F-number
      - 2 ±5%
      - 2 ±5%


### PR DESCRIPTION
Updated max FPS at 720p and 800p for OV9x82 sensors, as support was added for 120fps (previously max 60fps)